### PR TITLE
73 remove no podcast found alert in login journey

### DIFF
--- a/app/(app)/index.tsx
+++ b/app/(app)/index.tsx
@@ -1,4 +1,4 @@
-import { ScrollView, View, Text, Image, Pressable } from 'react-native';
+import { ScrollView, View, Text, Image, Pressable, ToastAndroid } from 'react-native';
 import NewsThumbnail from '../../components/NewsThumbnail';
 import React, { useContext, useEffect, useState } from 'react';
 import DateThumbnail from '../../components/DateThumbnail';
@@ -70,7 +70,7 @@ export default function homePage() {
     const date = new Date();
     const podcastUrl = await getNewestPodcastUrlFromSupabase(date);
     if (podcastUrl == null) {
-      alert('We hebben geen podcast kunnen vinden, probeer het morgen opnieuw');
+      ToastAndroid.show('Geen podcasts gevonden. Probeer het morgen opnieuw', ToastAndroid.LONG);
       return;
     }
     setAudioLink(podcastUrl.toString().replace('?', ''));

--- a/app/userInformation.tsx
+++ b/app/userInformation.tsx
@@ -19,7 +19,7 @@ const userInformation: FunctionComponent = () => {
     birthday: yup
       .date()
       .required('Birthday is required')
-      .max(new Date(), 'Cannot be in the future')
+      .max(new Date(Date.now() + 24 * 60 * 60 * 1000), 'Cannot be in the future')
       .test('is-at-least-13', 'Must be at least 13 years old', function (value) {
         const today = new Date();
         const minimumAgeDate = new Date(


### PR DESCRIPTION
I replaced the alert with a toast message. In my opinion this is less obtrusive, and then it also does not matter if it is shown earlier in the account creation process.